### PR TITLE
fix:タスクリストの表示方法を修正。

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -67,7 +67,7 @@ export default function Home() {
           <ul className={styles.taskList}>
             {todos.map((todo) => (
               <li className={styles.listItem} key={todo.id}>
-                <p>{todo.text}</p>
+                <p className={styles.listItemText}>{todo.text}</p>
                 <button
                   type="button"
                   className={styles.deleteButton}

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -58,6 +58,13 @@
   border: 1px solid #ddd;
   border-radius: 4px;
 }
+.listItemText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .deleteButton {
   padding: 5px 10px;
   font-size: 14px;


### PR DESCRIPTION
close https://github.com/tetsuya2223/nextjs-pages-todo-app/issues/15#issue-2817545403

タスクリストの表示方法を「3行以上であれば3点リーダーで省略される」ように修正しました。
①今後他のpタグを使用する際に影響しないように、`<p className={styles.listItemText}>{todo.text}</p>`でクラスを命名。
②
```
    .listItemText {
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: 2;
  overflow: hidden;
  text-overflow: ellipsis;
} 
```

とし、「3行以上であれば3点リーダーで省略される」様に修正しました。

<img width="651" alt="スクリーンショット 2025-01-29 17 42 15" src="https://github.com/user-attachments/assets/64b2b20b-374d-4dfc-ba5b-9900fe159f87" />


下記コミットメッセージになります。ご確認よろしくお願いいたします。
edac80cf8e65d16b3538a9dd999d8306dea2b993